### PR TITLE
Fixed: Issue #35: Created A Cpp model for List View in the Qml

### DIFF
--- a/Amey/QtQmlPrac/CMakeLists.txt
+++ b/Amey/QtQmlPrac/CMakeLists.txt
@@ -22,7 +22,13 @@ qt_add_qml_module(appQtQmlPrac
         SOURCES ExpenseItem.h
         SOURCES AppSettings.h
         SOURCES ExpenseCircleItem.h
+        SOURCES
+        QML_FILES
+        SOURCES expensemodel.h
+        QML_FILES ExpenseListView.qml
+        RESOURCES resources.qrc
 )
+qt6_add_resources(QT_RESOURCES resources.qrc)
 
 # Qt for iOS sets MACOSX_BUNDLE_GUI_IDENTIFIER automatically since Qt 6.1.
 # If you are developing for iOS or macOS you should consider setting an

--- a/Amey/QtQmlPrac/ExpenseListView.qml
+++ b/Amey/QtQmlPrac/ExpenseListView.qml
@@ -1,0 +1,42 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+Page {
+    id: root
+    width: 400
+    height: 400
+
+    header: ToolBar {
+        RowLayout {
+            anchors.fill: parent
+            Button {
+                text: "Back"
+                onClicked: stackView.pop()
+            }
+            Label {
+                text: "Expense List"
+                Layout.alignment: Qt.AlignCenter
+                Layout.fillWidth: true
+            }
+        }
+    }
+
+    ListView {
+        anchors.fill: parent
+        model: expensemodel
+        delegate: Rectangle {
+            width: parent.width
+            height: 50
+            color: index % 2 === 0 ? "#f0f0f0" : "#d0d0d0"
+            Row {
+                anchors.fill: parent
+                anchors.margins: 10
+                spacing: 20
+
+                Text { text: description; font.pixelSize: 16 }
+                Text { text: "₹ " + amount; font.pixelSize: 16 }
+            }
+        }
+    }
+}

--- a/Amey/QtQmlPrac/expensemodel.h
+++ b/Amey/QtQmlPrac/expensemodel.h
@@ -1,0 +1,56 @@
+#pragma once
+#include <QAbstractListModel>
+#include <QList>
+
+struct Expense {
+    QString description;
+    double amount;
+};
+
+class ExpenseModel : public QAbstractListModel {
+    Q_OBJECT
+public:
+    enum Roles {
+        DescriptionRole = Qt::UserRole + 1,
+        AmountRole
+    };
+
+    explicit ExpenseModel(QObject *parent = nullptr) : QAbstractListModel(parent) {
+        // Add some sample data (optional)
+        m_expenses.append({"Coffee", 120});
+        m_expenses.append({"Taxi", 300});
+    }
+
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override {
+        Q_UNUSED(parent);
+        return m_expenses.count();
+    }
+
+    QVariant data(const QModelIndex &index, int role) const override {
+        if (!index.isValid() || index.row() >= m_expenses.count())
+            return QVariant();
+
+        const Expense &expense = m_expenses.at(index.row());
+        if (role == DescriptionRole)
+            return expense.description;
+        else if (role == AmountRole)
+            return expense.amount;
+        return QVariant();
+    }
+
+    QHash<int, QByteArray> roleNames() const override {
+        return {
+            {DescriptionRole, "description"},
+            {AmountRole, "amount"}
+        };
+    }
+
+    Q_INVOKABLE void addExpense(const QString &desc, double amount) {
+        beginInsertRows(QModelIndex(), m_expenses.count(), m_expenses.count());
+        m_expenses.append({desc, amount});
+        endInsertRows();
+    }
+
+private:
+    QList<Expense> m_expenses;
+};


### PR DESCRIPTION
This is a simple expense tracker desktop application built using Qt 6.8, combining QML for the frontend and C++ for backend logic and data models. The app demonstrates:

- Displaying a basic expense item
- Using custom visual elements (QQuickPaintedItem)
- Interacting with a C++ backend (BackendService)
- Showing static app settings via singleton (AppSettings)
- Viewing a list of expenses from a C++ List Model (ExpenseModel) using QAbstractListModel
- StackView navigation between multiple QML pages